### PR TITLE
Switch to use_container_width for Streamlit images

### DIFF
--- a/myapp.py
+++ b/myapp.py
@@ -108,7 +108,7 @@ if not movies.empty:
                 st.text(row[title_col])
                 poster_url = fetch_poster(id_to_imdb.get(row[id_col])) if id_col else ""
                 if poster_url:
-                    st.image(poster_url, use_column_width=True)
+                    st.image(poster_url, use_container_width=True)
 
 # Barre de recherche de films
 st.markdown("<div class='search-container'>", unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- fix deprecated `use_column_width` by switching to `use_container_width`

## Testing
- `python3 -m py_compile myapp.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e60d1e3c83219f2edd7e9ff72ed9