### PR TITLE
Reorder widgets around "À la une" section

### DIFF
--- a/myapp.py
+++ b/myapp.py
@@ -120,29 +120,32 @@ if movie_query:
                             st.image(poster_url)
     st.markdown("---")
 
-selected_rec = st.selectbox("Source des recommandations", list(REC_PATHS.keys()))
-recs = load_recommendations(REC_PATHS[selected_rec])
+trending_container = st.container()
+with st.container():
+    selected_rec = st.selectbox("Source des recommandations", list(REC_PATHS.keys()))
+    recs = load_recommendations(REC_PATHS[selected_rec])
 
-user_ids = recs["user"].unique()
-user_id = st.selectbox("Utilisateur", sorted(user_ids))
-num_recs = st.slider("Nombre de recommandations", 1, 20, 10)
+    user_ids = recs["user"].unique()
+    user_id = st.selectbox("Utilisateur", sorted(user_ids))
+    num_recs = st.slider("Nombre de recommandations", 1, 20, 10)
+    show_recs = st.button("Afficher les recommandations")
 
-# Display personalized "A la une" section based on the selected user
-if not movies.empty:
-    st.subheader(f"\u00c0 la une pour l'utilisateur {user_id}")
-    trending = recs[recs["user"] == user_id].nlargest(12, "estimated_rating")
-    for start in range(0, len(trending), 4):
-        subset = trending.iloc[start : start + 4]
-        cols = st.columns(len(subset))
-        for col, (_, row) in zip(cols, subset.iterrows()):
-            movie_title = id_to_title.get(row["item"], f"Film {row['item']}")
-            poster_url = fetch_poster(id_to_imdb.get(row["item"]))
-            with col:
-                st.text(movie_title)
-                if poster_url:
-                    st.image(poster_url, use_container_width=True)
+with trending_container:
+    if not movies.empty:
+        st.subheader(f"\u00c0 la une pour l'utilisateur {user_id}")
+        trending = recs[recs["user"] == user_id].nlargest(12, "estimated_rating")
+        for start in range(0, len(trending), 4):
+            subset = trending.iloc[start : start + 4]
+            cols = st.columns(len(subset))
+            for col, (_, row) in zip(cols, subset.iterrows()):
+                movie_title = id_to_title.get(row["item"], f"Film {row['item']}")
+                poster_url = fetch_poster(id_to_imdb.get(row["item"]))
+                with col:
+                    st.text(movie_title)
+                    if poster_url:
+                        st.image(poster_url, use_container_width=True)
 
-if st.button("Afficher les recommandations"):
+if show_recs:
     user_recs = recs[recs["user"] == user_id].nlargest(int(num_recs), "estimated_rating")
     st.write(f"Recommandations pour l'utilisateur {user_id} :")
 


### PR DESCRIPTION
## Summary
- move the recommendation controls below the personalized "À la une" area

## Testing
- `python -m py_compile myapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6841e8f7094883218ead601a9255774e