### PR TITLE
Add trailer lookup via TMDb

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository contains a simple Streamlit application demonstrating a movie recommendation system.
 
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
+
+## Trailer display
+
+If you set the environment variable `TMDB_API_KEY` with your TMDb API key, the
+application will retrieve the YouTube trailer for each movie when available and
+show it using `st.video` in the description panel.

--- a/myapp.py
+++ b/myapp.py
@@ -69,6 +69,26 @@ def fetch_movie_details(imdb_id: int | str | None) -> dict:
         pass
     return {}
 
+
+def fetch_trailer_url(tmdb_id: int | str | None) -> str:
+    """Return the YouTube trailer URL using the TMDb API if available."""
+    if not tmdb_id:
+        return ""
+    api_key = os.getenv("TMDB_API_KEY")
+    if not api_key:
+        return ""
+    url = f"https://api.themoviedb.org/3/movie/{tmdb_id}/videos"
+    params = {"api_key": api_key}
+    try:
+        response = requests.get(url, params=params, timeout=5)
+        data = response.json()
+        for video in data.get("results", []):
+            if video.get("site") == "YouTube" and video.get("type") == "Trailer":
+                return f"https://www.youtube.com/watch?v={video.get('key')}"
+    except Exception:
+        pass
+    return ""
+
 @st.cache_data
 def load_recommendations(path: str) -> pd.DataFrame:
     """Load pre-computed top-n recommendations."""
@@ -122,8 +142,12 @@ try:
     id_to_title = dict(zip(movies[id_col], movies[title_col]))
     link_id_col = "movieId" if "movieId" in links.columns else links.columns[0]
     imdb_col = "imdbId" if "imdbId" in links.columns else links.columns[1]
+    tmdb_col = "tmdbId" if "tmdbId" in links.columns else links.columns[2]
     id_to_imdb = (
         dict(zip(links[link_id_col], links[imdb_col])) if not links.empty else {}
+    )
+    id_to_tmdb = (
+        dict(zip(links[link_id_col], links[tmdb_col])) if not links.empty else {}
     )
 except FileNotFoundError:
     st.warning(
@@ -132,6 +156,7 @@ except FileNotFoundError:
     movies = pd.DataFrame()
     id_to_title = {}
     id_to_imdb = {}
+    id_to_tmdb = {}
     id_col = title_col = None
     global_ratings = pd.Series(dtype=float)
 
@@ -201,6 +226,7 @@ with trending_container:
 if "selected_movie" in st.session_state:
     movie_id = st.session_state["selected_movie"]
     details = fetch_movie_details(id_to_imdb.get(movie_id))
+    trailer_url = fetch_trailer_url(id_to_tmdb.get(movie_id))
     title = details.get("title") or id_to_title.get(movie_id, f"Film {movie_id}")
     # Display the details in a narrower column so the poster doesn't fill
     # the whole screen
@@ -208,6 +234,8 @@ if "selected_movie" in st.session_state:
     with col_details.expander(title, expanded=True):
         if details.get("poster"):
             st.image(details["poster"], width=300)
+        if trailer_url:
+            st.video(trailer_url)
         genres = ""
         if not movies.empty and "genres" in movies.columns:
             match = movies[movies[id_col] == movie_id]


### PR DESCRIPTION
## Summary
- fetch trailers from TMDb API
- show the trailer video in the movie details pane
- document TMDb API key requirement

## Testing
- `python3 -m py_compile myapp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f7b991088321918d4158f6cd4577