### PR TITLE
Add trailer next to movie description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 This repository contains a simple Streamlit application demonstrating a movie recommendation system.
 
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
+
+## Trailer display
+
+If you set the environment variable `TMDB_API_KEY` with your TMDb API key, the
+application will retrieve the YouTube trailer for each movie when available and
+show it alongside the plot description using `st.video` in the details panel.


### PR DESCRIPTION
## Summary
- include movie plot in OMDb details
- show trailer or poster next to the plot when viewing movie details
- note in README that trailers appear alongside the plot description

## Testing
- `python3 -m py_compile myapp.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f7b991088321918d4158f6cd4577