### PR TITLE
Improve layout and remove trailer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,4 @@ This repository contains a simple Streamlit application demonstrating a movie re
 
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
 
-## Trailer display
-
-If you set the environment variable `TMDB_API_KEY` with your TMDb API key, the
-application will retrieve the YouTube trailer for each movie when available and
-
-show it alongside the plot description using `st.video` in the details panel.
+The original version could optionally show YouTube trailers when a `TMDB_API_KEY` was provided. This feature has been removed to simplify the interface.


### PR DESCRIPTION
## Summary
- simplify README about trailer support
- tweak the Netflix-like CSS
- move search and user selection to sidebar for better ergonomics
- remove trailer code from the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fedff088832181573de7b9ef6876