### PR TITLE
Filter user ratings in Streamlit app

### DIFF
--- a/myapp.py
+++ b/myapp.py
@@ -368,4 +368,7 @@ with tab_rated:
         movies[[id_col, title_col]], left_on="movieId", right_on=id_col, how="left"
     )
     merged = merged[["userId", "movieId", title_col, "rating"]]
-    st.dataframe(merged.head(100))
+
+    # Show only the ratings for the currently selected user
+    user_ratings = merged[merged["userId"] == user_id]
+    st.dataframe(user_ratings.head(100))


### PR DESCRIPTION
## Summary
- display only the selected user's ratings in the *Films notés* tab

## Testing
- `python -m py_compile myapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6842979337008321b8827d395d65fb2b