### PR TITLE
Add login and hashed password storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ This repository contains a simple Streamlit application demonstrating a movie re
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
 
 The original version could optionally show YouTube trailers when a `TMDB_API_KEY` was provided. This feature has been removed to simplify the interface.
+
+## User profiles
+
+The app now supports creating simple user profiles. A new profile is assigned
+an incremental identifier following the last existing user ID in the ratings
+dataset. Passwords are stored using a SHA-256 hash and displayed hashed in the
+"Liste des utilisateurs" table. A basic login form allows you to test profile
+authentication within the app.
+
+When a user logs in successfully, the sidebar user selector now includes a
+**Profil actif** option synced with the connected user. Selecting this option
+lets you rate movies and export those ratings together with the other users.


### PR DESCRIPTION
## Summary
- track password hashes with user list
- assign new profile IDs after highest ID in ratings dataset
- allow users to log in with pseudonym and password
- sync dropdown with the logged in user via **Profil actif**

## Testing
- `pyflakes myapp.py`
- `black myapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6842ab92d0dc8321bc856d605ca31e4e