### PR TITLE
Improve recommender UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This repository contains a simple Streamlit application demonstrating a movie re
 
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
 
-The original version could optionally show YouTube trailers when a `TMDB_API_KEY` was provided. This feature has been removed to simplify the interface.
+If a `TMDB_API_KEY` environment variable is defined, the app now fetches a
+YouTube trailer for each movie when available. Links to the corresponding IMDb
+and TMDB pages are also displayed in the description panel.
+
+The recommendation tab includes filters for genre, release year and minimum
+predicted rating so you can refine the suggestions.
 
 ## User profiles
 


### PR DESCRIPTION
## Summary
- restore trailer support using TMDB API
- link to IMDb and TMDB from movie details
- add filters (genre, year, min rating) to the recommendation tab
- document the new features

## Testing
- `python -m py_compile myapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6842e5ae063483218e87c9c34cb1d9ab