### PR TITLE
Fix featured tab persistence and trailer hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a simple Streamlit application demonstrating a movie re
 
 The app lets you search for movies and view personalized recommendations. Movie posters are displayed with a **Description** button for more info.
 
+The **À la une** section now keeps the same selection while you browse. Use the new **Rafraîchir** button to see another set of movies.
+
 If a `TMDB_API_KEY` environment variable is defined, the app now fetches a
 YouTube trailer for each movie when available. Links to the corresponding IMDb
 and TMDB pages are also displayed in the description panel.

--- a/myapp.py
+++ b/myapp.py
@@ -201,6 +201,13 @@ def show_movie_details(movie_id: int, user_id: int | None, state_key: str) -> No
                     key=f"trailer_{state_key}_{movie_id}",
                 ):
                     st.video(trailer_url)
+            elif os.environ.get("TMDB_API_KEY"):
+                st.info("Bande-annonce non trouvée.")
+            else:
+                st.info(
+                    "Définissez la variable d'environnement TMDB_API_KEY pour "
+                    "afficher les bandes-annonces."
+                )
 
         with col_side:
             if details.get("poster"):
@@ -336,7 +343,11 @@ with st.sidebar:
 
 with tab_featured:
     st.subheader("Films bien notés")
-    featured_movies = get_random_top_movies()
+    if "featured_movies" not in st.session_state:
+        st.session_state["featured_movies"] = get_random_top_movies()
+    if st.button("Rafraîchir", key="refresh_featured"):
+        st.session_state["featured_movies"] = get_random_top_movies()
+    featured_movies = st.session_state["featured_movies"]
     if not featured_movies:
         st.write("Aucun film à afficher.")
     else:


### PR DESCRIPTION
## Summary
- keep the featured movies stable until the user refreshes them
- display a hint when trailers are unavailable
- document the refresh button in the README

## Testing
- `python -m py_compile myapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6842e972c40c83218710b6db072c8ca1