### PR TITLE
Fix trending nlargest error

### DIFF
--- a/myapp.py
+++ b/myapp.py
@@ -502,6 +502,9 @@ with tab_rec:
                 right_on=id_col,
                 how="left",
             )
+            trending["estimated_rating"] = pd.to_numeric(
+                trending["estimated_rating"], errors="coerce"
+            )
             trending = trending[trending["estimated_rating"] >= min_rating]
             trending = trending[trending["year"].between(*year_range)]
             if genre_filter:


### PR DESCRIPTION
## Summary
- ensure `estimated_rating` is numeric before using `nlargest`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684304a061fc8321aa307201a494513f