### PR TITLE
Add algorithm choice for recommendations

### DIFF
--- a/myapp.py
+++ b/myapp.py
@@ -6,6 +6,7 @@ import hashlib
 import random
 import numpy as np
 from sklearn.metrics.pairwise import cosine_similarity
+from surprise import Dataset, Reader, SVD, KNNWithMeans
 
 st.set_page_config(page_title="Cinéma", layout="wide")
 
@@ -211,6 +212,46 @@ def recommend_user_based(
     return pd.DataFrame(top, columns=["movieId", "score"])
 
 
+def recommend_svd(ratings: pd.DataFrame, user_id: int, top_n: int = 10) -> pd.DataFrame:
+    """Return ``top_n`` SVD recommendations for ``user_id``."""
+    if ratings.empty or user_id not in ratings["userId"].unique():
+        return pd.DataFrame(columns=["movieId", "score"])
+
+    reader = Reader(rating_scale=(ratings["rating"].min(), ratings["rating"].max()))
+    data = Dataset.load_from_df(ratings[["userId", "movieId", "rating"]], reader)
+    trainset = data.build_full_trainset()
+    algo = SVD(random_state=0, n_factors=50)
+    algo.fit(trainset)
+
+    rated = set(ratings[ratings["userId"] == user_id]["movieId"])
+    all_items = set(ratings["movieId"].unique())
+    unrated = all_items - rated
+    testset = [(user_id, iid, 0) for iid in unrated]
+    preds = algo.test(testset)
+    top = sorted(preds, key=lambda x: x.est, reverse=True)[:top_n]
+    return pd.DataFrame([(int(p.iid), p.est) for p in top], columns=["movieId", "score"])
+
+
+def recommend_knn(ratings: pd.DataFrame, user_id: int, top_n: int = 10) -> pd.DataFrame:
+    """Return ``top_n`` KNN-based recommendations for ``user_id``."""
+    if ratings.empty or user_id not in ratings["userId"].unique():
+        return pd.DataFrame(columns=["movieId", "score"])
+
+    reader = Reader(rating_scale=(ratings["rating"].min(), ratings["rating"].max()))
+    data = Dataset.load_from_df(ratings[["userId", "movieId", "rating"]], reader)
+    trainset = data.build_full_trainset()
+    algo = KNNWithMeans(sim_options={"name": "cosine", "user_based": True})
+    algo.fit(trainset)
+
+    rated = set(ratings[ratings["userId"] == user_id]["movieId"])
+    all_items = set(ratings["movieId"].unique())
+    unrated = all_items - rated
+    testset = [(user_id, iid, 0) for iid in unrated]
+    preds = algo.test(testset)
+    top = sorted(preds, key=lambda x: x.est, reverse=True)[:top_n]
+    return pd.DataFrame([(int(p.iid), p.est) for p in top], columns=["movieId", "score"])
+
+
 def show_movie_details(movie_id: int, user_id: int | None, state_key: str) -> None:
     """Display movie details with rating option."""
     details = fetch_movie_details(id_to_imdb.get(movie_id))
@@ -398,6 +439,11 @@ with st.sidebar:
     else:
         user_id = None if selected_user == "All users" else int(selected_user)
 
+    model_option = st.selectbox(
+        "Algorithme de recommandation",
+        ["Cosinus", "Funk SVD", "KNN"],
+    )
+
     movie_query = st.text_input("Rechercher un film")
 
 with tab_featured:
@@ -494,7 +540,12 @@ with tab_rec:
             if trending.empty:
                 if os.path.exists(RATINGS_ALL_PATH):
                     ratings_all = load_all_ratings(RATINGS_ALL_PATH)
-                    trending = recommend_user_based(ratings_all, user_id, top_n=30)
+                    if model_option == "Cosinus":
+                        trending = recommend_user_based(ratings_all, user_id, top_n=30)
+                    elif model_option == "Funk SVD":
+                        trending = recommend_svd(ratings_all, user_id, top_n=30)
+                    else:
+                        trending = recommend_knn(ratings_all, user_id, top_n=30)
                     trending = trending.rename(
                         columns={"movieId": "item", "score": "estimated_rating"}
                     )
@@ -611,6 +662,12 @@ with tab_profile:
     pseudo = st.text_input("Pseudonyme")
     password = st.text_input("Mot de passe", type="password")
 
+    model_option_profile = st.selectbox(
+        "Algorithme de recommandation",
+        ["Cosinus", "Funk SVD", "KNN"],
+        key="profile_model",
+    )
+
     if "profile_ratings" not in st.session_state:
         st.session_state["profile_ratings"] = {}
     if "profile_pool" not in st.session_state:
@@ -678,7 +735,12 @@ with tab_profile:
                 st.success(f"Profil enregistré avec l'identifiant {next_id}.")
 
                 ratings_all = pd.read_csv(RATINGS_ALL_PATH)
-                rec_df = recommend_user_based(ratings_all, next_id)
+                if model_option_profile == "Cosinus":
+                    rec_df = recommend_user_based(ratings_all, next_id)
+                elif model_option_profile == "Funk SVD":
+                    rec_df = recommend_svd(ratings_all, next_id)
+                else:
+                    rec_df = recommend_knn(ratings_all, next_id)
                 if not rec_df.empty:
                     rec_df["title"] = rec_df["movieId"].map(id_to_title)
                     st.subheader("Films recommandés :")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pandas
 scikit-learn
 requests
 numpy
+scikit-surprise
 


### PR DESCRIPTION
## Summary
- add Surprise models imports
- implement `recommend_svd` and `recommend_knn`
- provide algorithm choice in sidebar and profile creation
- use selected algorithm for dynamic recommendations
- update requirements with scikit-surprise

## Testing
- `python -m py_compile myapp.py`
- `pytest -q`
- `pip install -r requirements.txt -q`

------
https://chatgpt.com/codex/tasks/task_e_68430af3c1048321899171c83a09f643