### PR TITLE
Fix scikit-surprise install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ pip install -r requirements.txt
 ```
 
 The `requirements.txt` file lists `streamlit`, `pandas`, `scikit-learn` and the
-other dependencies needed to run the application.
+other dependencies needed to run the application. Numpy is pinned to a
+pre-2.0 release to ensure compatibility with `scikit-surprise`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ streamlit
 pandas
 scikit-learn
 requests
-numpy
+numpy<2
 scikit-surprise
 


### PR DESCRIPTION
## Summary
- pin numpy to stay below 2 to avoid build errors
- document numpy pinning in README

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68430e1708dc832188850dbc15bceea7